### PR TITLE
Adjust sofa_deriver to be python3 only.

### DIFF
--- a/sofa_deriver.py
+++ b/sofa_deriver.py
@@ -289,9 +289,11 @@ def reprocess_sofa_c_lines(inlns, func_prefix, libname, inlinelicensestr):
         elif ln.startswith('**  This revision:'):
             incopyright = True
             # Start of the copyright/versioning section - need to strip this
-            # because it contains SOFA references.  Put in the correct inline
-            # license instead.
+            # because it contains SOFA references.  Instead, put this line
+            # with useful date information and the correct inline license.
+            outlns.append(ln)
             if inlinelicensestr:
+                outlns.append('**\n')
                 outlns.append(inlinelicensestr)
         else:
             # Need to replace 'iau' b/c other SOFA functions are often called.


### PR DESCRIPTION
This removes the need to import six, which fewer and fewer people will have (well, it meant the code didn't work as it was for me at least).

Also updated comments to be more PEP8 compliant, and removed an unused function.